### PR TITLE
make the launch options unchangeable

### DIFF
--- a/cfgen/index.html
+++ b/cfgen/index.html
@@ -391,7 +391,7 @@
 		  </div>
 		  <div class="panel-body">
 			<div class="well well-lg">
-			<input type="text" class="form-control" id="loptions" onClick="this.setSelectionRange(0, this.value.length)" value=""/>  
+			<input type="text" class="form-control" id="loptions" onClick="this.setSelectionRange(0, this.value.length)" value="" readOnly/>  
 			</div>
 			<div class="well">
 			<li><input type="radio" name="launch" id="full" onclick="updatescreenmode();" checked />


### PR DESCRIPTION
Sorry, for last time. readOnly should still trigger the onClick event if Im correct