### PR TITLE
Fixed incorrect links. Default to https where available.

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,12 +183,12 @@
         </a>
       </div>
       <div class="col-md-2">
-        <a href="http://pan.tf" target="_blank"><img src="./img/partner/rsp.jpg" class="img-circle img-thumbnail">
+        <a href="https://pan.tf" target="_blank"><img src="./img/partner/rsp.jpg" class="img-circle img-thumbnail">
           <p>Ready Steady Pan</p>
         </a>
       </div>
       <div class="col-md-2">
-        <a href="http://www.kritzkast.com/" target="_blank"><img src="./img/partner/kritz.jpg" class="img-circle img-thumbnail">
+        <a href="https://www.kritzkast.com/" target="_blank"><img src="./img/partner/kritz.jpg" class="img-circle img-thumbnail">
           <p>KritzKast</p>
         </a>
       </div>
@@ -198,12 +198,12 @@
         </a>
       </div>
       <div class="col-md-2 col-md-offset-2">
-        <a href="http://huds.tf/" target="_blank"><img src="./img/partner/hugstf.jpg" class="img-circle img-thumbnail">
+        <a href="https://hugs.tf/" target="_blank"><img src="./img/partner/hugstf.jpg" class="img-circle img-thumbnail">
           <p>hugs.tf</p>
         </a>
       </div>
       <div class="col-md-2">
-        <a href="http://teamwork.tf/" target="_blank"><img src="./img/partner/teamwork.jpg" class="img-circle img-thumbnail">
+        <a href="https://teamwork.tf/" target="_blank"><img src="./img/partner/teamwork.jpg" class="img-circle img-thumbnail">
           <p>teamwork.tf</p>
         </a>
       </div>
@@ -213,7 +213,7 @@
         </a>
       </div>
       <div class="col-md-2">
-        <a href="http://huds.tf/" target="_blank"><img src="./img/partner/essentials.jpg" class="img-circle img-thumbnail">
+        <a href="https://essentials.tf/" target="_blank"><img src="./img/partner/essentials.jpg" class="img-circle img-thumbnail">
           <p>essentials.tf</p>
         </a>
       </div>


### PR DESCRIPTION
Fixed hugs.tf and essentials.tf images pointing towards huds.tf.
Explicitly use https for the sites that can.